### PR TITLE
マイコンボードのボタンを使った例

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -5,16 +5,20 @@
 
 #include "mbed.h"
 
-#define WAIT_TIME_MS 500 
+#define WAIT_TIME_MS 500
 DigitalOut led1(LED1);
+DigitalIn button(BUTTON1);
 
-int main()
-{
-    printf("This is the bare metal blinky example running on Mbed OS %d.%d.%d.\n", MBED_MAJOR_VERSION, MBED_MINOR_VERSION, MBED_PATCH_VERSION);
+int main() {
+  printf("This is the bare metal blinky example running on Mbed OS %d.%d.%d.\n",
+         MBED_MAJOR_VERSION, MBED_MINOR_VERSION, MBED_PATCH_VERSION);
 
-    while (true)
-    {
-        led1 = !led1;
+  while (true) {
+    led1 = !led1;
+    if( button ){
         thread_sleep_for(WAIT_TIME_MS);
+    } else {
+        thread_sleep_for(WAIT_TIME_MS / 10);
     }
+  }
 }


### PR DESCRIPTION
マイコンボード上の青いボタンを押すと、LEDの点滅が速くなります